### PR TITLE
Adjust to work with pyenv

### DIFF
--- a/bootstrap-tools.sh
+++ b/bootstrap-tools.sh
@@ -13,7 +13,7 @@ readonly minimum_python_version=(3 6 6)
 readonly minimum_docker_compose_version=(1 23 2)
 readonly minimum_vault_version=(0 9 3)
 
-readonly PYTHON='python3.6'
+readonly PYTHON="$(which python3.6)"
 readonly PIP="$PYTHON -m pip"
 
 # --- BEGIN parse options


### PR DESCRIPTION
sudo $PYTHON doesn't see anything if pyenv is being used from a non-root user.

might cause issues if $PYTHON is ever used in a way other than as an executable's path/name.

may be difficult to find all the namespaces $PYTHON ends up in; it's curl-ed from certain things like [inca](https://github.com/crowd-ai/inca/blob/dev/scripts/bootstrap-dev-common.sh) and [ssh-crowdai](https://github.com/crowd-ai/ssh-crowdai/blob/master/bootstrap.sh).